### PR TITLE
Support frozen objects

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -566,9 +566,9 @@ export function makeChildObservable(value, parentMode:ValueMode, context) {
 			throw "Illegal State";
 	}
 
-	if (Array.isArray(value))
+	if (Array.isArray(value) && Object.isExtensible(value))
 		return createObservableArray(<[]> value, childMode, true, context);
-	if (isPlainObject(value))
+	if (isPlainObject(value) && Object.isExtensible(value))
 		return extendObservableHelper(value, value, childMode, context);
 	return value;
 }

--- a/test/makereactive.js
+++ b/test/makereactive.js
@@ -32,6 +32,7 @@ test('isObservable', function(t) {
 
     t.equal(m.isObservable(m.observable([])), true);
     t.equal(m.isObservable(m.observable({})), true);
+    t.equal(m.isObservable(m.observable(Object.freeze({}))), false);
     t.equal(m.isObservable(m.observable(function() {})), true);
 
     t.equal(m.isObservable([]), false);


### PR DESCRIPTION
This code:
```js
var arr = mobservable.observable([]);
var person = Object.freeze({ name: 'bob' })
arr.push(person)
```
throws error `Cannot define property:$mobservable, object is not extensible.`

This also prevents from pushing react elements into mobservable array:
```
buttons.push(<button title="test" />);
```